### PR TITLE
bugfix for decoding bytes fields with length zero

### DIFF
--- a/protobuf.py
+++ b/protobuf.py
@@ -245,6 +245,8 @@ class EofWrapper:
         '''
         Reads a string. Raises EOFError on end of stream.
         '''
+        if size == 0:
+            return ''
         if self.__limit is not None:
             size = min(size, self.__limit)
             self.__limit -= size

--- a/run-unit-tests.py
+++ b/run-unit-tests.py
@@ -243,6 +243,15 @@ class TestMessageType(unittest.TestCase):
         self.assertEqual(i.next(), (1, 'b', UVarint, Flags.REPEATED))
         self.assertEqual(i.next(), (2, 'c', Bytes, Flags.PACKED_REPEATED))
 
+    def test_empty_optional_bytes(self):
+        '''
+        Regression test to prove that a bytes field of length zero is loaded correctly.
+        '''
+        Type1 = MessageType()
+        Type1.add_field(1, 'a', Bytes)
+        msg = Type1.loads('\n\x00')
+        self.assertEqual(msg.a, '')
+
 class TestEmbeddedMessage(unittest.TestCase):
 
     def test_dumps_1(self):


### PR DESCRIPTION
Loading a bytes field with length zero will call EofWrapper.read(0).

EofWrapper.read(0) was always raising EOFError, so decoding of the current message would stop.