### PR TITLE
Exclude every test package when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Pavel Perestoronin',
     author_email='eigenein@gmail.com',
     url='https://github.com/eigenein/protobuf',
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['tests*']),
     zip_safe=True,
     install_requires=[
         'dataclasses>=0.6,<1.0; python_version < "3.7"',


### PR DESCRIPTION
As of now only `tests` package is excluded when installing pure-protobuf, but `tests.types` slips in:

```
>>> find_packages(exclude=['tests'])
['pure_protobuf', 'tests.types', 'pure_protobuf.types', 'pure_protobuf.serializers']
```

Using a wildcard, `tests` and all its subpackages are excluded:

```
>>> find_packages(exclude=['tests*'])
['pure_protobuf', 'pure_protobuf.types', 'pure_protobuf.serializers']
```