### PR TITLE
support for `field(..., packed=False)` to serialize unpacked repeated fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## `master`
+-  New: support for `field(..., packed=False)` to serialize unpacked repeated fields
+
 ## `2.0.1`
 
 - Fix: F541 f-string is missing placeholders

--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ class Message:
     foo: List[int32] = field(1, default_factory=list)
 ```
 
+In case, unpacked encoding is explicitly wanted, the `packed`-argument of `field` can be used as in:
+
+```python
+from dataclasses import dataclass
+from typing import List
+
+from pure_protobuf.dataclasses_ import field, message
+from pure_protobuf.types import int32
+
+@message
+@dataclass
+class Message:
+    foo: List[int32] = field(1, default_factory=list, packed=False)
+```
+
 It's also possible to wrap a field type with [`typing.Optional`](https://docs.python.org/3/library/typing.html#typing.Optional). If `None` is assigned to an `Optional` field, then the field will be skipped during serialization.
 
 ### Default values


### PR DESCRIPTION
This is a possible implementation for #90.