### PR TITLE
Add first Oneof prototype

### DIFF
--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -50,7 +50,6 @@ class Message(ABC):
     """
 
     __protobuf_fields__: Dict[int, Field]
-    __one_of_fields__: Set[Field]
     serializer: ClassVar[Serializer]
     type_url: ClassVar[str]
 

--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -35,7 +35,7 @@ from pure_protobuf.fields import (
     UnpackedRepeatedField,
 )
 from pure_protobuf.io_ import IO
-from pure_protobuf.oneof import OneOf_, OneOfPartInfo
+from pure_protobuf.oneof import OneOf_, OneOfPartInfo, scheme
 from pure_protobuf.serializers import IntEnumSerializer, MessageSerializer, PackingSerializer, Serializer
 from pure_protobuf.types import NoneType
 
@@ -197,9 +197,11 @@ def make_one_of_field(field_: OneOf_, name: str) -> Tuple[OneOfField, Dict[int, 
     # to make cyclic reference from child to parent and from parent to children
     # better to change later I think
     name_to_field: Dict[str, OneOfPartField] = {}
-    parent = OneOfField(name, field_.parts, name_to_field)
+
+    parts = scheme(field_)
+    parent = OneOfField(name, parts, name_to_field)
     child_fields = {}
-    for part_ in field_.parts:
+    for part_ in parts:
         num, child_ = make_field(part_.number, part_.name, part_.type_, False)
 
         child_fields[num] = OneOfPartField(num, parent, child_)

--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -8,21 +8,7 @@ from abc import ABC
 from collections import abc
 from enum import IntEnum
 from io import BytesIO
-from typing import (
-    Any,
-    ByteString,
-    ClassVar,
-    Dict,
-    Iterable,
-    List,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    get_type_hints,
-)
+from typing import Any, ByteString, ClassVar, Dict, Iterable, List, Tuple, Type, TypeVar, Union, cast, get_type_hints
 
 from pure_protobuf import serializers, types
 from pure_protobuf.enums import WireType

--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -147,14 +147,8 @@ def message(cls: Type[T]) -> Type[TMessage]:
     type_hints = get_type_hints(cls)
 
     casted_cls = cast(Type[TMessage], cls)
-
     # Used to list all fields and locate fields by field number.
     casted_cls.__protobuf_fields__ = {}
-
-    # Used to handle one of case. Separated from other fields because
-    # OneOf field is not part of message, only sugar.
-    # As a consequence OneOf field doesn't have any number in message.
-    casted_cls.__one_of_fields__ = set()
 
     for field_ in dataclasses.fields(cls):
         if field_.metadata['isoneof']:

--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -21,18 +21,12 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_type_hints
+    get_type_hints,
 )
 
 from pure_protobuf import serializers, types
 from pure_protobuf.enums import WireType
-from pure_protobuf.fields import (
-    Field,
-    NonRepeatedField,
-    OneOfField,
-    PackedRepeatedField,
-    UnpackedRepeatedField
-)
+from pure_protobuf.fields import Field, NonRepeatedField, OneOfField, PackedRepeatedField, UnpackedRepeatedField
 from pure_protobuf.io_ import IO
 from pure_protobuf.serializers import IntEnumSerializer, MessageSerializer, PackingSerializer, Serializer
 from pure_protobuf.types import NoneType
@@ -229,17 +223,13 @@ def make_one_of_field(field: OneOf_, field_type: Any, name: str) -> Tuple[int, F
         raise TypeError("Oneof field type should be declared using Union type"
                         f"not {field_type}")
 
-    args = set(field_type.__args__)
-    fields = {}
-    for (name_, datacls_field), type_ in zip(field.fields.items(), args):
-        fields[name_] = make_field(
-            datacls_field.metadata['number'],
-            datacls_field.name,
-            type_,
-            False
-        )
+    fields = {
+        name_: make_field(part.metadata['number'], name_, type_, False)
+        for (name_, part), type_ in zip(field.fields.items(), field_type.__args__)
+    }
 
     first_field = next(iter(field.fields.values()))
+    # decided to use number of first field, but not sure if it's ok
     return first_field.metadata['number'], OneOfField(name, fields)
 
 

--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -109,12 +109,12 @@ def optional_field(number: int, *args, **kwargs) -> Any:
 
 
 def one_of(**parts: Tuple[type, int]) -> OneOf_:
-    scheme = (
+    scheme_ = tuple(
         OneOfPartInfo(name, type_, number)
         for name, (type_, number) in parts.items()
     )
 
-    default = OneOf_(*scheme)
+    default = OneOf_(scheme_)
     return _field(-1, isoneof=True, default=default)
 
 

--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -62,7 +62,6 @@ class Message(ABC):
     type_url: ClassVar[str]
 
     def validate(self):
-        print("Validation: ", self)
         self.serializer.validate(self)
 
     def dump(self, io: IO):

--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -93,7 +93,6 @@ class OneOfType:
         self.types = types
 
 
-
 class _oneof:
     def __getitem__(self, index):
         if isinstance(index, tuple):
@@ -143,12 +142,6 @@ class OneOf_:
         return None
 
 
-@dataclasses.dataclass
-class OneOfPart:
-    type_: Type
-    number: int
-
-
 class OptionalFieldDescriptor:
     def __init__(self, number, *args, **kwargs):
         # do we need field here?
@@ -192,7 +185,7 @@ def optional_field(number: int, *args, **kwargs) -> Any:
     return field(number, *args, default=None, **kwargs)
 
 
-def one_of(**parts: OneOfPart) -> OneOf_:
+def one_of(**parts: dataclasses.Field) -> OneOf_:
     return OneOf_(**parts)
 
 
@@ -244,14 +237,14 @@ def message(cls: Type[T]) -> Type[TMessage]:
     return cast(Type[TMessage], cls)
 
 
-def make_one_of_field(field: OneOf_, type_: OneOfType, name: str) -> Tuple[int, Field]:
+def make_one_of_field(field: OneOf_, field_type: OneOfType, name: str) -> Tuple[int, Field]:
     """
     Figure out how to serialize and de-serialize oneof field.
     Returns the number of first field in oneof and a corresponding ``Field``
     instance.
     """
     fields = {}
-    for (name_, datacls_field), type_ in zip(field.fields.items(), type_.types):
+    for (name_, datacls_field), type_ in zip(field.fields.items(), field_type.types):
         fields[name_] = make_field(
             datacls_field.metadata['number'],
             datacls_field.name,

--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -86,6 +86,7 @@ class Message(ABC):
                 getattr(other, field_.name),
             ))
 
+
 class OneOf_:
     """
     Defines an oneof field.
@@ -96,11 +97,9 @@ class OneOf_:
         super().__setattr__('fields', fields)
         super().__setattr__('set_value', None)
 
-
     def __getattr__(self, name):
         if name not in self.fields:
             raise AttributeError(f"Field {name} is not found")
-
 
         if self.set_value is not None:
             field_name, value = self.set_value
@@ -135,6 +134,7 @@ class OptionalFieldDescriptor:
 
     def __set__(self, instance, value):
         self.value = value
+
 
 def load(cls: Type[TMessage], io: IO) -> TMessage:
     """
@@ -172,6 +172,7 @@ def one_of(**parts: dataclasses.Field) -> OneOf_:
 
 def one_of_field(type_: Type, number: int) -> Any:
     return optional_field(number)
+
 
 def message(cls: Type[T]) -> Type[TMessage]:
     """

--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -165,15 +165,14 @@ def make_one_of_field(field_: OneOf_, name: str) -> Dict[int, OneOfPartField]:
 
     Returns the corresponding ``Field`` instance.
     """
-    scheme_ = scheme(field_)
     child_fields = (
         # TODO: what to do with packed?
         make_field(part_.number, part_.name, part_.type_, False)
-        for part_ in scheme_
+        for part_ in scheme(field_)
     )
 
     children: Dict[int, OneOfPartField] = {
-        num: OneOfPartField(num, name, child_field, scheme_)
+        num: OneOfPartField(num, name, field_, child_field)
         for num, child_field in child_fields
     }
 

--- a/pure_protobuf/fields.py
+++ b/pure_protobuf/fields.py
@@ -160,7 +160,7 @@ class OneOfField(Field):
         self.name = name
         self.fields = fields
 
-    def active_field_and_value(self, value: OneOf_) -> Optional[Tuple[Field, Any]]:
+    def active_field_and_value(self, value: 'OneOf_') -> Optional[Tuple[Field, Any]]:
         set_field = value.which_one_of
         if set_field is not None:
             number, active_field = self.fields[set_field]
@@ -169,7 +169,7 @@ class OneOfField(Field):
 
         return None
 
-    def validate(self, value: OneOf_):
+    def validate(self, value: 'OneOf_'):
         res = self.active_field_and_value(value)
         if res is not None:
             field, value = res

--- a/pure_protobuf/fields.py
+++ b/pure_protobuf/fields.py
@@ -187,6 +187,6 @@ class OneOfPartField(Field):
 
     def load(self, wire_type: WireType, io: IO) -> Any:
         field_value = self.origin.load(wire_type, io)
-        result = OneOf_(*self.scheme)
+        result = OneOf_(self.scheme)
         setattr(result, self.origin.name, field_value)
         return result

--- a/pure_protobuf/fields.py
+++ b/pure_protobuf/fields.py
@@ -4,7 +4,9 @@
 
 from abc import ABC, abstractmethod
 from io import BytesIO
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, Optional, Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from pure_protobuf.dataclasses_ import OneOf_
 
 from pure_protobuf.enums import WireType
 from pure_protobuf.io_ import IO, Dumps
@@ -154,18 +156,20 @@ class OneOfField(Field):
     See also: https://developers.google.com/protocol-buffers/docs/proto3#oneof
     """
 
-    def __init__(self, name: str, fields: Dict[str, Field]):
+    def __init__(self, name: str, fields: Dict[str, Tuple[int, Field]]):
         self.name = name
         self.fields = fields
 
-    def active_field_and_value(self, value: 'OneOf_') -> Optional[Tuple[Field, Any]]:
+    def active_field_and_value(self, value: OneOf_) -> Optional[Tuple[Field, Any]]:
         set_field = value.which_one_of
         if set_field is not None:
             number, active_field = self.fields[set_field]
             value = getattr(value, set_field)
             return active_field, value
 
-    def validate(self, value: 'OneOf_'):
+        return None
+
+    def validate(self, value: OneOf_):
         res = self.active_field_and_value(value)
         if res is not None:
             field, value = res

--- a/pure_protobuf/fields.py
+++ b/pure_protobuf/fields.py
@@ -4,7 +4,7 @@
 
 from abc import ABC, abstractmethod
 from io import BytesIO
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, Tuple
 
 from pure_protobuf.enums import WireType
 from pure_protobuf.io_ import IO, Dumps
@@ -155,7 +155,8 @@ class OneOfField(Field):
     Handles oneof field
     See also: https://developers.google.com/protocol-buffers/docs/proto3#oneof
     """
-    def __init__(self, name: str, parts: List[OneOfPartInfo], fields: Dict[str, 'OneOfPartField']):
+    def __init__(self, name: str, parts: Tuple[OneOfPartInfo, ...],
+                 fields: Dict[str, 'OneOfPartField']):
         # ignoring super().__init__(...) on purpose because
         # there is no particular Serializer for this kind field
         # and used one of Serializer from OneOf_ parts

--- a/pure_protobuf/fields.py
+++ b/pure_protobuf/fields.py
@@ -207,10 +207,10 @@ class OneOfPartField(Field):
 
         # check only if this particular field is set
         which_set = value.which_one_of
-        if which_set is None or which_set != self.origin.name:
+        if which_set != self.origin.name:
             return
 
-        original_value = getattr(value, self.origin.name)
+        original_value = getattr(value, which_set)
         self.serializer.validate(original_value)
 
     def dump(self, value: OneOf_, io: IO):

--- a/pure_protobuf/fields.py
+++ b/pure_protobuf/fields.py
@@ -4,7 +4,8 @@
 
 from abc import ABC, abstractmethod
 from io import BytesIO
-from typing import Any, Dict, Iterable, Optional, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple
+
 if TYPE_CHECKING:
     from pure_protobuf.dataclasses_ import OneOf_
 

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -32,10 +32,10 @@ class OneOf_:
         super().__setattr__(_OneOfAttrs.SET_VALUE.value, None)
 
     def __getattr__(self, name):
-        if name not in getattr(self, _OneOfAttrs.FIELDS.value):
+        if name not in self.__fields__:
             raise AttributeError(f"Field {name} is not found")
 
-        set_value = getattr(self, _OneOfAttrs.SET_VALUE.value)
+        set_value = self.__set_value__
         if set_value is not None:
             field_name, real_value = set_value
             if field_name == name:
@@ -44,14 +44,14 @@ class OneOf_:
         return None
 
     def __setattr__(self, name, value):
-        if name not in getattr(self, _OneOfAttrs.FIELDS.value):
+        if name not in self.__fields__:
             raise AttributeError(f"Field {name} is not found")
 
         super().__setattr__(_OneOfAttrs.SET_VALUE.value, (name, value))
 
     @property
     def which_one_of(self) -> Optional[str]:
-        set_value = getattr(self, _OneOfAttrs.SET_VALUE.value)
+        set_value = self.__set_value__
         if set_value is None:
             return None
 
@@ -60,9 +60,7 @@ class OneOf_:
 
     @property
     def __internals(self) -> Tuple[Any, Any, Any]:
-        return (getattr(self, _OneOfAttrs.FIELDS.value),
-                getattr(self, _OneOfAttrs.PARTS.value),
-                getattr(self, _OneOfAttrs.SET_VALUE.value))
+        return (self.__fields__, self.__parts__, self.__set_value__)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, OneOf_):

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -76,4 +76,4 @@ class OneOf_:
         fields, parts, set_value = self.__internals
         return (f"{fields} \n"
                 f"parts: {parts} \n"
-                f"set: {set_value} \n")
+                f"set: {set_value}")

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -39,7 +39,7 @@ class OneOf_:
     Defines an oneof field.
     See also: https://developers.google.com/protocol-buffers/docs/proto3#oneof
     """
-    def __init__(self, *parts: OneOfPartInfo):
+    def __init__(self, parts: Tuple[OneOfPartInfo, ...]):
         # ugly sets to get round custom setattr
         super().__setattr__(_OneOfAttrs.FIELDS.value, frozenset(part.name for part in parts))
         super().__setattr__(_OneOfAttrs.PARTS.value, parts)

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -49,6 +49,12 @@ class OneOf_:
 
         super().__setattr__(_OneOfAttrs.SET_VALUE.value, (name, value))
 
+    def __delattr__(self, name):
+        if name not in self.__fields__:
+            raise AttributeError(f"Field {name} is not found")
+
+        super().__setattr__(_OneOfAttrs.SET_VALUE.value, None)
+
     @property
     def which_one_of(self) -> Optional[str]:
         set_value = self.__set_value__

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -17,7 +17,7 @@ class _OneOfAttrs(Enum):
 
 
 def scheme(obj: 'OneOf_') -> Tuple[OneOfPartInfo, ...]:
-    return getattr(obj, _OneOfAttrs.PARTS.value)
+    return obj.__parts__
 
 
 class OneOf_:

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -53,6 +53,10 @@ class OneOf_:
         if name not in self.__fields__:
             raise AttributeError(f"Field {name} is not found")
 
+        if self.which_one_of != name:
+            raise AttributeError(f"Field {name} is not set,"
+                                 f"{self.which_one_of} is set")
+
         super().__setattr__(_OneOfAttrs.SET_VALUE.value, None)
 
     @property

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -68,15 +68,10 @@ class OneOf_:
         if not isinstance(other, OneOf_):
             return NotImplemented
 
-        self_fields, self_parts, self_setvalue = self.__internals
-        other_fields, other_parts, other_setvalue = other.__internals
-        return self_fields == other_fields and \
-            self_parts == other_parts and \
-            self_setvalue == other_setvalue
+        return self.__internals == other.__internals
 
     def __hash__(self) -> int:
-        fields, parts, set_value = self.__internals
-        return hash((fields, parts, set_value))
+        return hash(self.__internals)
 
     # for debug purposes I guess
     def __repr__(self) -> str:

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -75,5 +75,5 @@ class OneOf_:
     def __repr__(self) -> str:
         fields, parts, set_value = self.__internals
         return (f"{fields} \n"
-                f"set: {parts} \n"
-                f"parts: {set_value}")
+                f"parts: {set_value} \n"
+                f"set: {set_value} \n")

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -1,7 +1,7 @@
 import dataclasses
 import functools
 from enum import Enum
-from typing import Any, Callable, Optional, Tuple, Type
+from typing import Any, Callable, Optional, Tuple
 
 
 @dataclasses.dataclass(frozen=True)
@@ -22,12 +22,8 @@ def scheme(obj: 'OneOf_') -> Tuple[OneOfPartInfo, ...]:
     return obj.__parts__
 
 
-def internals(self) -> Tuple[Any, Any, Any]:
+def _internals(self) -> Tuple[Any, Any, Any]:
     return (self.__fields__, self.__parts__, self.__set_value__)
-
-
-def origin_class(self) -> Type[Any]:
-    return self.__origin_class__
 
 
 def _name_in_attrs_check(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore
@@ -83,14 +79,14 @@ class OneOf_:
         if not isinstance(other, OneOf_):
             return NotImplemented
 
-        return internals(self) == internals(other)
+        return _internals(self) == _internals(other)
 
     def __hash__(self) -> int:
-        return hash(internals(self))
+        return hash(_internals(self))
 
     # for debug purposes I guess
     def __repr__(self) -> str:
-        fields, parts, set_value = internals(self)
+        fields, parts, set_value = _internals(self)
         return (f"{fields} \n"
                 f"parts: {parts} \n"
                 f"set: {set_value}")

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -1,0 +1,61 @@
+import dataclasses
+from typing import Any, Optional
+
+
+@dataclasses.dataclass(frozen=True)
+class OneOfPartInfo:
+    name: str
+    type_: type
+    number: int
+
+
+class OneOf_:
+    """
+    Defines an oneof field.
+    See also: https://developers.google.com/protocol-buffers/docs/proto3#oneof
+    """
+    def __init__(self, *parts: OneOfPartInfo):
+        # ugly sets to get round custom setattr
+        # fields created as tuple on purposes
+        super().__setattr__('fields', tuple(part.name for part in parts))
+        super().__setattr__('parts', parts)
+        super().__setattr__('set_value', None)
+
+    def __getattr__(self, name):
+        if name not in self.fields:
+            raise AttributeError(f"Field {name} is not found")
+
+        if self.set_value is not None:
+            field_name, value = self.set_value
+            if field_name == name:
+                return value
+
+        return None
+
+    def __setattr__(self, name, value):
+        if name not in self.fields:
+            raise AttributeError(f"Field {name} is not found")
+
+        super().__setattr__('set_value', (name, value))
+
+    @property
+    def which_one_of(self) -> Optional[str]:
+        if self.set_value is not None:
+            field_name, _ = self.set_value
+            return field_name
+        return None
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, OneOf_) and \
+            other.fields == self.fields and \
+            other.parts == self.parts and \
+            other.set_value == self.set_value
+
+    def __hash__(self) -> int:
+        return hash((self.fields, self.parts, self.set_value))
+
+    # for debug purposes I guess
+    def __repr__(self) -> str:
+        return (f"{self.fields} \n"
+                f"set: {self.parts} \n"
+                f"parts: {self.set_value}")

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -40,10 +40,11 @@ class OneOf_:
 
     @property
     def which_one_of(self) -> Optional[str]:
-        if self.set_value is not None:
-            field_name, _ = self.set_value
-            return field_name
-        return None
+        if self.set_value is None:
+            return None
+
+        field_name, _ = self.set_value
+        return field_name
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, OneOf_) and \

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -1,7 +1,7 @@
 import dataclasses
 import functools
 from enum import Enum
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Type
 
 
 @dataclasses.dataclass(frozen=True)
@@ -9,6 +9,7 @@ class OneOfPartInfo:
     name: str
     type_: type
     number: int
+    packed: bool = True
 
 
 class _OneOfAttrs(Enum):
@@ -25,6 +26,10 @@ def internals(self) -> Tuple[Any, Any, Any]:
     return (self.__fields__, self.__parts__, self.__set_value__)
 
 
+def origin_class(self) -> Type[Any]:
+    return self.__origin_class__
+
+
 def _name_in_attrs_check(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore
     @functools.wraps(func)
     def inner(self, name, *args):
@@ -39,10 +44,10 @@ class OneOf_:
     Defines an oneof field.
     See also: https://developers.google.com/protocol-buffers/docs/proto3#oneof
     """
-    def __init__(self, parts: Tuple[OneOfPartInfo, ...]):
+    def __init__(self, scheme_: Tuple[OneOfPartInfo, ...]):
         # ugly sets to get round custom setattr
-        super().__setattr__(_OneOfAttrs.FIELDS.value, frozenset(part.name for part in parts))
-        super().__setattr__(_OneOfAttrs.PARTS.value, parts)
+        super().__setattr__(_OneOfAttrs.FIELDS.value, frozenset(part.name for part in scheme_))
+        super().__setattr__(_OneOfAttrs.PARTS.value, scheme_)
         super().__setattr__(_OneOfAttrs.SET_VALUE.value, None)
 
     @_name_in_attrs_check

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -42,23 +42,18 @@ class OneOf_:
 
     @__name_in_attrs_check
     def __getattr__(self, name):
-        set_value = self.__set_value__
-        if set_value is not None:
-            field_name, real_value = set_value
-            if field_name == name:
-                return real_value
+        if self.which_one_of == name:
+            _, value = self.__set_value__
+            return value
 
         return None
 
     @__name_in_attrs_check
     def __delattr__(self, name):
-        set_value = self.__set_value__
-        if set_value is not None:
-            field_name, _ = set_value
-            if field_name == name:
-                return super().__setattr__(_OneOfAttrs.SET_VALUE.value, None)
+        if self.which_one_of == name:
+            return super().__setattr__(_OneOfAttrs.SET_VALUE.value, None)
 
-        raise AttributeError(f"Field {name} is not set,"
+        raise AttributeError(f"Field {name} is not set, "
                              f"{self.which_one_of} is set")
 
     @__name_in_attrs_check

--- a/pure_protobuf/oneof.py
+++ b/pure_protobuf/oneof.py
@@ -75,5 +75,5 @@ class OneOf_:
     def __repr__(self) -> str:
         fields, parts, set_value = self.__internals
         return (f"{fields} \n"
-                f"parts: {set_value} \n"
+                f"parts: {parts} \n"
                 f"set: {set_value} \n")

--- a/pure_protobuf/serializers/__init__.py
+++ b/pure_protobuf/serializers/__init__.py
@@ -369,7 +369,6 @@ class MessageSerializer(Serializer):
     def validate(self, value: Any):
         if not isinstance(value, self.type_):
             raise ValueError(f'{self.type_} is expected, but got {type(value)}')
-        print(value)
         for field_ in value.__protobuf_fields__.values():
             field_.validate(getattr(value, field_.name))
 

--- a/pure_protobuf/serializers/__init__.py
+++ b/pure_protobuf/serializers/__init__.py
@@ -369,11 +369,13 @@ class MessageSerializer(Serializer):
     def validate(self, value: Any):
         if not isinstance(value, self.type_):
             raise ValueError(f'{self.type_} is expected, but got {type(value)}')
+        print(value)
         for field_ in value.__protobuf_fields__.values():
             field_.validate(getattr(value, field_.name))
 
     def dump(self, value: Any, io: IO):
-        for number, field_ in value.__protobuf_fields__.items():
+        # number is not needed here
+        for field_ in value.__protobuf_fields__.values():
             field_value = getattr(value, field_.name)
             try:
                 field_.dump(field_value, io)

--- a/pure_protobuf/serializers/__init__.py
+++ b/pure_protobuf/serializers/__init__.py
@@ -7,7 +7,7 @@ Serializers for the dataclasses interface.
 import struct
 from abc import ABC
 from enum import IntEnum
-from itertools import chain, count
+from itertools import count
 from struct import pack, unpack
 from typing import Any, Dict, Type
 
@@ -369,12 +369,12 @@ class MessageSerializer(Serializer):
     def validate(self, value: Any):
         if not isinstance(value, self.type_):
             raise ValueError(f'{self.type_} is expected, but got {type(value)}')
-        for field_ in chain(value.__protobuf_fields__.values(), value.__one_of_fields__):
+        for field_ in value.__protobuf_fields__.values():
             field_.validate(getattr(value, field_.name))
 
     def dump(self, value: Any, io: IO):
         # number is not needed here
-        for field_ in chain(value.__protobuf_fields__.values(), value.__one_of_fields__):
+        for field_ in value.__protobuf_fields__.values():
             field_value = getattr(value, field_.name)
             try:
                 field_.dump(field_value, io)
@@ -388,7 +388,6 @@ class MessageSerializer(Serializer):
                 key = unsigned_varint_serializer.load(io)
             except ValueError:
                 break
-
             wire_type = WireType(key & 0b111)
             field = self.type_.__protobuf_fields__.get(key >> 3)
             if field is not None:

--- a/tests/test_oneof.py
+++ b/tests/test_oneof.py
@@ -20,10 +20,10 @@ class ComplexObj:
     d: bool
 
 
-def create_one_of_pair(scheme: Tuple[OneOfPartInfo, ...], field_name: str,
+def create_one_of_pair(scheme_: Tuple[OneOfPartInfo, ...], field_name: str,
                        value1: Any, value2: Any) -> Tuple[OneOf_, OneOf_]:
-    oneof_value1 = OneOf_(*scheme)
-    oneof_value2 = OneOf_(*scheme)
+    oneof_value1 = OneOf_(scheme_)
+    oneof_value2 = OneOf_(scheme_)
 
     setattr(oneof_value1, field_name, value1)
     setattr(oneof_value2, field_name, value2)
@@ -71,7 +71,7 @@ def test_hash_doesnt_work_with_unhashable_type():
         b: float
 
     with raises(TypeError):
-        one_of_value = OneOf_(OneOfPartInfo('complex', ComplexObj, 1))
+        one_of_value = OneOf_((OneOfPartInfo('complex', ComplexObj, 1), ))
         one_of_value.complex = ComplexObj(a=5, b=1.)
         hash(one_of_value)
 
@@ -90,7 +90,7 @@ def test_which_one_of():
         [1, 2, 3, 4, 5]
     )
 
-    oneof_msg = OneOf_(*parts)
+    oneof_msg = OneOf_(parts)
 
     for part_, val in zip(parts, values):
         setattr(oneof_msg, part_.name, val)
@@ -110,7 +110,7 @@ def test_usual_message_sets_work():
         OneOfPartInfo('f1', ComplexObj, 10),
         OneOfPartInfo('f2', List[int], 9)
     )
-    oneof_msg = OneOf_(*parts)
+    oneof_msg = OneOf_(parts)
 
     expected, expected_name = 5, 'foo'
     oneof_msg.foo = expected  # every set actually overrides

--- a/tests/test_oneof.py
+++ b/tests/test_oneof.py
@@ -1,0 +1,74 @@
+"""
+`pure-protobuf` contributors © 2011-2022
+"""
+
+import dataclasses
+from typing import Any, Tuple
+
+from pytest import mark, raises
+
+from pure_protobuf.oneof import OneOf_, OneOfPartInfo
+
+
+@dataclasses.dataclass(frozen=True)
+class ComplexObj:
+    a: int
+    b: float
+    c: complex
+    d: bool
+
+
+def create_one_of_pair(scheme: Tuple[OneOfPartInfo, ...], field_name: str,
+                       value1: Any, value2: Any) -> Tuple[OneOf_, OneOf_]:
+    oneof_value1 = OneOf_(*scheme)
+    oneof_value2 = OneOf_(*scheme)
+
+    setattr(oneof_value1, field_name, value1)
+    setattr(oneof_value2, field_name, value2)
+    return oneof_value1, oneof_value2
+
+
+@mark.parametrize('field_name, value1, value2', [
+    ('abc', "foo", "foo"),
+    ('foo', 5, 5),
+    ('f1', ComplexObj(1, 1., 1j, True), ComplexObj(1, 1., 1j, True))
+])
+def test_one_of_field_eq_hash(field_name: str, value1: Any, value2: Any):
+    parts = (
+        OneOfPartInfo('abc', str, 5),
+        OneOfPartInfo('foo', int, 10),
+        OneOfPartInfo('f1', ComplexObj, 11)
+    )
+    oneof_value1, oneof_value2 = create_one_of_pair(parts, field_name, value1, value2)
+
+    assert oneof_value1 == oneof_value2
+    assert hash(oneof_value1) == hash(oneof_value2)
+
+
+@mark.parametrize('field_name, value1, value2', [
+    ('abc', "foo", "abudu"),
+    ('foo', 5, -1),
+    ('f1', ComplexObj(1, 1., 1j, True), ComplexObj(2, 2., 2j, False))
+])
+def test_one_of_field_not_eq_hash(field_name: str, value1: Any, value2: Any):
+    parts = (
+        OneOfPartInfo('abc', str, 5),
+        OneOfPartInfo('foo', int, 10),
+        OneOfPartInfo('f1', ComplexObj, 10)
+    )
+    oneof_value1, oneof_value2 = create_one_of_pair(parts, field_name, value1, value2)
+
+    assert oneof_value1 != oneof_value2
+    assert hash(oneof_value1) != hash(oneof_value2)
+
+
+def test_hash_doesnt_work_with_unhashable_type():
+    @dataclasses.dataclass
+    class ComplexObj:
+        a: int
+        b: float
+
+    with raises(TypeError):
+        one_of_value = OneOf_(OneOfPartInfo('complex', ComplexObj, 1))
+        one_of_value.complex = ComplexObj(a=5, b=1.)
+        hash(one_of_value)

--- a/tests/test_oneof.py
+++ b/tests/test_oneof.py
@@ -70,9 +70,9 @@ def test_hash_doesnt_work_with_unhashable_type():
         a: int
         b: float
 
+    one_of_value = OneOf_((OneOfPartInfo('complex', ComplexObj, 1), ))
+    one_of_value.complex = ComplexObj(a=5, b=1.)
     with raises(TypeError):
-        one_of_value = OneOf_((OneOfPartInfo('complex', ComplexObj, 1), ))
-        one_of_value.complex = ComplexObj(a=5, b=1.)
         hash(one_of_value)
 
 
@@ -211,3 +211,22 @@ def test_class_sets_one_set():
     with raises(AttributeError):
         # trying to delete unset method
         del obj.oneof_msg.f1
+
+
+def test_many_one_of():
+    @message
+    @dataclasses.dataclass
+    class A:
+        msg: OneOf_ = one_of(
+            a=part(int32, 1),
+            b=part(str, 2),
+            c=part(bool, 3)
+        )
+
+    a = A()
+    a.a = 42
+    b = A()
+    b.b = "42"
+
+    assert a.a == 42
+    assert b.b == "42"

--- a/tests/test_oneof.py
+++ b/tests/test_oneof.py
@@ -3,11 +3,13 @@
 """
 
 import dataclasses
-from typing import Any, Tuple
+from typing import Any, List, Tuple
 
 from pytest import mark, raises
 
+from pure_protobuf.dataclasses_ import field, message, one_of, part
 from pure_protobuf.oneof import OneOf_, OneOfPartInfo
+from pure_protobuf.types import int32
 
 
 @dataclasses.dataclass(frozen=True)
@@ -72,3 +74,131 @@ def test_hash_doesnt_work_with_unhashable_type():
         one_of_value = OneOf_(OneOfPartInfo('complex', ComplexObj, 1))
         one_of_value.complex = ComplexObj(a=5, b=1.)
         hash(one_of_value)
+
+
+def test_which_one_of():
+    parts = (
+        OneOfPartInfo('abc', str, 5),
+        OneOfPartInfo('foo', int, 10),
+        OneOfPartInfo('f1', ComplexObj, 10),
+        OneOfPartInfo('f2', List[int], 9)
+    )
+    values = (
+        "foo",
+        5,
+        ComplexObj(1, 1., 1j, False),
+        [1, 2, 3, 4, 5]
+    )
+
+    oneof_msg = OneOf_(*parts)
+
+    for part_, val in zip(parts, values):
+        setattr(oneof_msg, part_.name, val)
+
+        assert oneof_msg.which_one_of == part_.name
+        assert getattr(oneof_msg, oneof_msg.which_one_of) == val
+
+
+def name_and_value(oneof_msg: OneOf_) -> Tuple[str, Any]:
+    return oneof_msg.which_one_of, getattr(oneof_msg, oneof_msg.which_one_of)  # type: ignore
+
+
+def test_usual_message_sets_work():
+    parts = (
+        OneOfPartInfo('abc', str, 5),
+        OneOfPartInfo('foo', int, 10),
+        OneOfPartInfo('f1', ComplexObj, 10),
+        OneOfPartInfo('f2', List[int], 9)
+    )
+    oneof_msg = OneOf_(*parts)
+
+    expected, expected_name = 5, 'foo'
+    oneof_msg.foo = expected  # every set actually overrides
+    field_name, val = name_and_value(oneof_msg)
+    assert field_name == expected_name
+    assert val == expected
+
+    expected, expected_name = "aaa", 'abc'
+    oneof_msg.abc = expected
+    field_name, val = name_and_value(oneof_msg)
+    assert field_name == expected_name
+    assert val == expected
+
+    expected, expected_name = ComplexObj(1, 1., 1j, True), 'f1'
+    oneof_msg.f1 = expected
+    field_name, val = name_and_value(oneof_msg)
+    assert field_name == expected_name
+    assert val == expected
+
+    expected, expected_name = [1, 2, 3, 4], 'f2'
+    oneof_msg.f2 = expected
+    field_name, val = name_and_value(oneof_msg)
+    assert field_name == expected_name
+    assert val == expected
+
+
+@message
+@dataclasses.dataclass
+class SomeObj:
+    a: int32 = field(1)
+    b: str = field(2)
+
+
+@message
+@dataclasses.dataclass
+class Example:
+    usual_value: int32 = field(3)
+    another_one: str = field(4)
+
+    oneof_msg: OneOf_ = one_of(
+        abc=part(str, 5),
+        foo=part(int32, 10),
+        f1=part(SomeObj, 7),
+        f2=part(List[int32], 9)
+    )
+
+
+def hardcoded_which_one_of(oneof_msg: OneOf_):
+    if oneof_msg.abc is not None:
+        return "abc", oneof_msg.abc
+    elif oneof_msg.foo is not None:
+        return "foo", oneof_msg.foo
+    elif oneof_msg.f1 is not None:
+        return "f1", oneof_msg.f1
+    elif oneof_msg.f2 is not None:
+        return "f2", oneof_msg.f2
+
+
+def class_assertions(expected_name: str, expected_val: Any, oneof_msg: OneOf_):
+    field_name, val = name_and_value(oneof_msg)
+    assert field_name == expected_name
+    assert val == expected_val
+    assert oneof_msg.which_one_of == expected_name
+
+    _r_name, _r_val = hardcoded_which_one_of(oneof_msg)
+    assert _r_name == expected_name
+    assert _r_val == expected_val
+
+
+def test_class_sets_one_set():
+    obj = Example(usual_value=5, another_one='111')
+
+    # foo
+    expected, expected_name = 5, 'foo'
+    obj.oneof_msg.foo = expected  # every set actually overrides previous value
+    class_assertions(expected_name, expected, obj.oneof_msg)
+
+    # abc
+    expected, expected_name = "aaa", 'abc'
+    obj.oneof_msg.abc = expected
+    class_assertions(expected_name, expected, obj.oneof_msg)
+
+    # f1
+    expected, expected_name = SomeObj(1, "aaa"), 'f1'
+    obj.oneof_msg.f1 = expected
+    class_assertions(expected_name, expected, obj.oneof_msg)
+
+    # f2
+    expected, expected_name = [1, 2, 3, 4], 'f2'
+    obj.oneof_msg.f2 = expected
+    class_assertions(expected_name, expected, obj.oneof_msg)

--- a/tests/test_oneof.py
+++ b/tests/test_oneof.py
@@ -202,3 +202,8 @@ def test_class_sets_one_set():
     expected, expected_name = [1, 2, 3, 4], 'f2'
     obj.oneof_msg.f2 = expected
     class_assertions(expected_name, expected, obj.oneof_msg)
+
+    # unset
+    del obj.oneof_msg.f2
+    assert obj.oneof_msg.f2 is None
+    assert obj.oneof_msg.which_one_of is None

--- a/tests/test_oneof.py
+++ b/tests/test_oneof.py
@@ -207,3 +207,7 @@ def test_class_sets_one_set():
     del obj.oneof_msg.f2
     assert obj.oneof_msg.f2 is None
     assert obj.oneof_msg.which_one_of is None
+
+    with raises(AttributeError):
+        # trying to delete unset method
+        del obj.oneof_msg.f1

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -341,19 +341,12 @@ def test_many_messages_with_one_of_field():
     value2.msg.b = "42"
     bytes_2 = b'\x12\x0242'
 
-    print("++!+" * 25)
-    print(value)
-    print("++!+" * 25)
     assert value.dumps() == bytes_
     assert A.loads(bytes_) == value
     assert A.loads(value.dumps()) == value
-    print("++!+" * 25)
-    print(A.loads(bytes_))
 
     assert value2.dumps() == bytes_2
     assert A.loads(bytes_2) == value2
     assert A.loads(value2.dumps()) == value2
-    print("++!+" * 25)
-    print(A.loads(bytes_2))
 
     assert value.msg.a == 42

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -315,3 +315,45 @@ def test_one_of_field():
     assert value.dumps() == bytes_
     assert SampleMessage.loads(bytes_) == value
     assert SampleMessage.loads(value.dumps()) == value
+
+
+def test_many_messages_with_one_of_field():
+    # message A {
+    #   oneof msg {
+    #     int32 a = 1;
+    #     strin b = 2;
+    #   }
+    # }
+
+    @message
+    @dataclass
+    class A:
+        msg: OneOf_ = one_of(
+            a=part(int32, 1),
+            b=part(str, 2)
+        )
+
+    value = A()
+    value.msg.a = 42
+    bytes_ = b'\x08*'
+
+    value2 = A()
+    value2.msg.b = "42"
+    bytes_2 = b'\x12\x0242'
+
+    print("++!+" * 25)
+    print(value)
+    print("++!+" * 25)
+    assert value.dumps() == bytes_
+    assert A.loads(bytes_) == value
+    assert A.loads(value.dumps()) == value
+    print("++!+" * 25)
+    print(A.loads(bytes_))
+
+    assert value2.dumps() == bytes_2
+    assert A.loads(bytes_2) == value2
+    assert A.loads(value2.dumps()) == value2
+    print("++!+" * 25)
+    print(A.loads(bytes_2))
+
+    assert value.msg.a == 42

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -5,11 +5,11 @@
 # noinspection PyCompatibility
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any, List, Optional, Type
+from typing import Any, List, Optional, Union, Type
 
 from pytest import fixture, mark, raises
 
-from pure_protobuf.dataclasses_ import field, message
+from pure_protobuf.dataclasses_ import field, message, one_of, OneOf, one_of_field, optional_field
 from pure_protobuf.enums import WireType
 from pure_protobuf.serializers import (
     BooleanSerializer,
@@ -270,3 +270,41 @@ def test_enum():
 
     assert value.dumps() == bytes_
     assert Test.loads(bytes_) == value
+
+
+def test_one_of_field():
+    # message SubMessage {
+    #     string id = 1;
+    #     int32 b = 3;
+    # }
+    # 
+    # message SampleMessage {
+    #   oneof test_oneof {
+    #     string name = 4;
+    #     SubMessage sub_message = 9;
+    #   }
+    # }
+    @message
+    @dataclass
+    class SubMessage:
+        id: str = field(1)
+        b: int32 = field(3)
+
+    @message
+    @dataclass
+    class SampleMessage:
+        test_oneof: OneOf[str, SubMessage] = one_of(
+                name = one_of_field(str, 4), 
+                sub_message = one_of_field(SubMessage, 9)
+        )
+        # name: Optional[str] = optional_field(4)
+        # sub_message: Optional[SubMessage] = optional_field(9)
+
+    value = SampleMessage()
+    value.test_oneof.sub_message = SubMessage(id='123', b=5)
+    bytes_ = b'J\x07\n\x03123\x18\x05'
+    assert value.dumps() == bytes_
+    
+    value.test_oneof.name = "Some string"
+    bytes_ = b'"\x0bSome string'
+    assert value.dumps() == bytes_

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -5,7 +5,7 @@
 # noinspection PyCompatibility
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any, List, Optional, Union, Type
+from typing import Any, List, Optional, Type, Union
 
 from pytest import fixture, mark, raises
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -306,9 +306,6 @@ def test_one_of_field():
     # here could be
     bytes_ = b'J\x07\n\x03123\x18\x05'
     assert value.dumps() == bytes_
-    print("+++!+" * 25)
-    print(SampleMessage.loads(bytes_))
-    print(value)
     assert SampleMessage.loads(bytes_) == value
     assert SampleMessage.loads(value.dumps()) == value
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional, Union, Type
 
 from pytest import fixture, mark, raises
 
-from pure_protobuf.dataclasses_ import field, message, one_of, OneOf, one_of_field, optional_field
+from pure_protobuf.dataclasses_ import field, message, one_of, one_of_field, optional_field
 from pure_protobuf.enums import WireType
 from pure_protobuf.serializers import (
     BooleanSerializer,
@@ -293,7 +293,7 @@ def test_one_of_field():
     @message
     @dataclass
     class SampleMessage:
-        test_oneof: OneOf[str, SubMessage] = one_of(
+        test_oneof: Union[str, SubMessage] = one_of(
                 name = one_of_field(str, 4), 
                 sub_message = one_of_field(SubMessage, 9)
         )

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional, Union, Type
 
 from pytest import fixture, mark, raises
 
-from pure_protobuf.dataclasses_ import field, message, one_of, one_of_field, optional_field
+from pure_protobuf.dataclasses_ import field, message, one_of, one_of_field
 from pure_protobuf.enums import WireType
 from pure_protobuf.serializers import (
     BooleanSerializer,
@@ -277,7 +277,7 @@ def test_one_of_field():
     #     string id = 1;
     #     int32 b = 3;
     # }
-    # 
+    #
     # message SampleMessage {
     #   oneof test_oneof {
     #     string name = 4;
@@ -294,8 +294,8 @@ def test_one_of_field():
     @dataclass
     class SampleMessage:
         test_oneof: Union[str, SubMessage] = one_of(
-                name = one_of_field(str, 4), 
-                sub_message = one_of_field(SubMessage, 9)
+            name=one_of_field(str, 4),
+            sub_message=one_of_field(SubMessage, 9)
         )
         # name: Optional[str] = optional_field(4)
         # sub_message: Optional[SubMessage] = optional_field(9)
@@ -304,7 +304,7 @@ def test_one_of_field():
     value.test_oneof.sub_message = SubMessage(id='123', b=5)
     bytes_ = b'J\x07\n\x03123\x18\x05'
     assert value.dumps() == bytes_
-    
+
     value.test_oneof.name = "Some string"
     bytes_ = b'"\x0bSome string'
     assert value.dumps() == bytes_


### PR DESCRIPTION
Seems to work. Not sure if it's fully complete, but some tests work. 

Not sure also if such implementation of OneOf is good one:
- conceptually I added two kind of `Field` now: OneOfField and OneOfPartField
- OneOfField is not used for deserialization (I tweaked
  MessageSerializer a bit)
- OneOfPartField's are not used to serialiaze, OneOfField is used for it
- For every  submessage there is separate `OneOfPartField`, and they kinda know about it's parent (or enclosing one?)
   For example submessages here are `name` and `sub_message`, parent is `test_oneof`: 
   ```python
    # message SubMessage {
    #     string id = 1;
    #     int32 b = 3;
    # }
    #
    # message SampleMessage {
    #   oneof test_oneof {
    #     string name = 4;
    #     SubMessage sub_message = 9;
    #   }
    # }

    @message
    @dataclass
    class SubMessage:
        id: str = field(1)
        b: int32 = field(3)

    @message
    @dataclass
    class SampleMessage:
        test_oneof: OneOf_ = one_of(
            name=part(str, 4),
            sub_message=part(SubMessage, 9)
        )
    ``` 
 
- I didn't implement distinct Serilazers for this Fields, but probably should

Mb will clean up later and rename some methods/variables. 

Anyway design on user side looks good to me now. Probably better to start here: function [test_one_of_field](https://github.com/eigenein/protobuf/compare/master...aleksZubakov:one-of-implementation?expand=1#diff-40fa549b2e04aff4adbd50658b9bfff04fb9750a75eda1cb415ef005818e258eR275) (hope link gonna work) in `test_serializers.py` first.