### PR TITLE
Supports integers in float fields

### DIFF
--- a/pure_protobuf/serializers/__init__.py
+++ b/pure_protobuf/serializers/__init__.py
@@ -344,7 +344,7 @@ class FloatSerializer(Serializer):
     wire_type = WireType.LONG
 
     def validate(self, value: Any):
-        if not isinstance(value, float):
+        if not isinstance(value, float) and not isinstance(value, int):
             raise ValueError("a floating-point value is expected")
 
     def dump(self, value: Any, io: IO):
@@ -363,7 +363,7 @@ class DoubleSerializer(Serializer):
     wire_type = WireType.LONG_LONG
 
     def validate(self, value: Any):
-        if not isinstance(value, float):
+        if not isinstance(value, float) and not isinstance(value, int):
             raise ValueError("a floating-point value is expected")
 
     def dump(self, value: Any, io: IO):


### PR DESCRIPTION
We often try to serialize data on float fields with a value of 0.

We shouldn't have to explicitly cast the integers into float. An integer can always be casted as a float by python.

Thanks!

PS: to be completely honest I haven't tested the code myself, I figure you have an easy way to do it yourself.