### PR TITLE
Update metadata instead of repace in _field helper

### DIFF
--- a/pure_protobuf/dataclasses_.py
+++ b/pure_protobuf/dataclasses_.py
@@ -116,9 +116,13 @@ def _field(number: int, *args, packed=True, isoneof=False, **kwargs) -> Any:
     Convenience function to assign field numbers.
     Calls the standard ``dataclasses.field`` function with the metadata assigned.
     """
-    metadata = {"number": number, "packed": packed, "isoneof": isoneof}
+    proto_metadata = {"number": number, "packed": packed, "isoneof": isoneof}
 
-    return dataclasses.field(*args, metadata=metadata, **kwargs)
+    metadata = kwargs.pop("metadata", None)
+    if metadata is not None:
+        proto_metadata.update(metadata)
+
+    return dataclasses.field(*args, metadata=proto_metadata, **kwargs)
 
 
 def field(number: int, *args, packed=True, **kwargs) -> Any:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -77,3 +77,9 @@ Box = message(Box)  # type: ignore
 
 def test_recursive_dataclass():
     assert cast(Message, Box(value=1, box=Box(value=2))).dumps() == b"\x08\x02\x12\x02\x08\x04"
+
+
+def test_other_metadata():
+    dataclass_field = field(1, packed=False, metadata={"foo": True})
+
+    assert set(["number", "packed", "isoneof", "foo"]) == set(dataclass_field.metadata.keys())


### PR DESCRIPTION
This will allow for a simple combination of protobuf messages and other metadata, like dataclass json custom encoders/decoders